### PR TITLE
Add cloudron.io to list of known users

### DIFF
--- a/users.html
+++ b/users.html
@@ -95,11 +95,12 @@
               <div class="col-md-9">
                 <div class="bs-sidebar" role="complementary">
                   <ul class="nav bs-sidenav">
+                    <li><a href="https://cloudron.io">Cloudron - A platform for self-hosting web apps</a></li>
                     <li><a href="http://www.craigslist.org/about/thanks">Craigslist</a></li>
-                    <li><a href="http://www.fortantispam.com/">Fort Anti-Spam</a></li>
                     <li><a href="https://www.emailitin.com/">Email It In - A service to email files to Google Drive, Dropbox or Skydrive</a></li>
-                    <li><a href="http://temp-mail.org/">Temp Mail - a Temporary Email Address provider</a></li>
+                    <li><a href="http://www.fortantispam.com/">Fort Anti-Spam</a></li>
                     <li><a href="http://mirusresearch.com/">Mirus Research - Address simplification/forwarding services</a></li>
+                    <li><a href="http://temp-mail.org/">Temp Mail - a Temporary Email Address provider</a></li>
                     <li><a href="https://threatwave.com/">ThreatWave - Hidden insights and data from email</a></li>
                   </ul>
                 </div>


### PR DESCRIPTION
I made the list alphabetical. Let me know if you want to keep the order and put Cloudron to the end of the list.

The Cloudron comes with a mail server that uses Haraka for inbound and outbound mail (this has been the main reason for all my PRs to Haraka).

The mail source code is at https://git.cloudron.io/cloudron/mail-addon (MIT). 

Goes without saying, but thanks for this awesome project :100: 